### PR TITLE
fix: allow ovos-workshop 9.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 keywords = ["ovos", "skill", "plugin"]
 dependencies = [
     "ovos-plugin-manager>=2.1.0,<3.0.0",
-    "ovos_workshop>=0.0.12,<9.0.0"
+    "ovos_workshop>=0.0.12,<10.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Lifts the `ovos-workshop<9.0.0` cap to `<10.0.0`, matching the fleet-wide bump (ovos-core 2.5.x requires `ovos-workshop>=9.0.2a1`; the old cap forces a conflicting resolution in constraint-driven installs such as raspOVOS images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded compatibility with newer `ovos_workshop` releases, including versions below 10.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->