### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Camera Skill
 
-Camera skill for OpenVoiceOS, needs the companion plugin [ovos-PHAL-plugin-camera](https://github.com/OpenVoiceOS/ovos-PHAL-plugin-camera) or [ovos-PHAL-plugin-termux](https://github.com/HiveMindInsiders/ovos-PHAL-plugin-termux)
-
-## Description
-
-This skill allows you to ask to take pictures using a connected webcam. You can configure various settings to customize its behavior.
+This skill takes pictures with a connected webcam through voice commands on OpenVoiceOS. It needs a companion plugin: [ovos-PHAL-plugin-camera](https://github.com/OpenVoiceOS/ovos-PHAL-plugin-camera) or [ovos-PHAL-plugin-termux](https://github.com/HiveMindInsiders/ovos-PHAL-plugin-termux).
 
 ## Examples
 
@@ -12,7 +8,7 @@ This skill allows you to ask to take pictures using a connected webcam. You can 
 
 ## Settings
 
-The `settings.json` file allows you to configure the behavior of the Camera Skill. Below are the available settings:
+The `settings.json` file configures the skill. The table below lists the available settings.
 
 | Setting Name         | Type     | Default       | Description                                                                 |
 |----------------------|----------|---------------|-----------------------------------------------------------------------------|
@@ -30,4 +26,11 @@ The `settings.json` file allows you to configure the behavior of the Camera Skil
 }
 ```
 
+## Related Projects
 
+* [ovos-PHAL-plugin-camera](https://github.com/OpenVoiceOS/ovos-PHAL-plugin-camera): PHAL plugin that connects this skill to a webcam.
+* [ovos-PHAL-plugin-termux](https://github.com/HiveMindInsiders/ovos-PHAL-plugin-termux): alternative PHAL plugin for Termux and Android devices.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Rewrites the README prose in Simplified Technical English for clarity. Adds a Related Projects section linking the companion PHAL plugins already referenced in the text, and a License section. All facts, settings table, and examples are unchanged.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README introduction and settings descriptions.
  * Added Related Projects and License sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->